### PR TITLE
occamy: Boot from SPI flash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ fw_payload.*
 build
 *.elf
 *.a
+*.gz
+*.bin
 rootfs/usr/bin/tetris
 
 riscv-gnu-toolchain/build

--- a/.gitmodules
+++ b/.gitmodules
@@ -27,4 +27,5 @@
 
 [submodule "u-boot"]
 	path = u-boot
-	url = git@github.com:pulp-platform/u-boot.git
+	url = https://github.com/pulp-platform/u-boot.git
+	branch = occamy


### PR DESCRIPTION
This adds/changes the following `make` targets required to boot Linux on occamy from the SPI flash:

* `uImage.bin`: U-Boot compatible Linux image. Can be loaded into the VCU128's flash via Vivado.
* `fw_payload`: Change the OpenSBI payload from Linux to U-Boot.

Furthermore, the `u-boot` submodule is bumped.

These are the current steps required to boot linux:
1. Load `uImage.bin` via Vivado into the VCU128's SPI flash.
2. Load Occamy bitstream, execute zero-stage boot loader from bootrom.
3. Connect to occamy via OpenOCD/gdb, load `fw_payload.elf` (OpenSBI + U-Boot), execute.